### PR TITLE
feat: Refactor turnout logic into xDuinoRails_Turnouts library

### DIFF
--- a/lib/xDuinoRails_Turnouts/src/xDuinoRails_Turnouts.cpp
+++ b/lib/xDuinoRails_Turnouts/src/xDuinoRails_Turnouts.cpp
@@ -1,0 +1,177 @@
+#include "xDuinoRails_Turnouts.h"
+
+// --- Unified Constructor ---
+xDuinoRails_Turnout::xDuinoRails_Turnout(int id, const char* name, MotorType motorType, int pin1, int pin2, int sensorPin1, int sensorPin2, int angleMin, int angleMax)
+    : _id(id), _name(name), _motorType(motorType), _sensorPin1(sensorPin1), _sensorPin2(sensorPin2),
+      _state(STATE_IDLE), _targetPosition(0) {
+    if (_motorType == MOTOR_SERVO) {
+        new (&_motor.servo) Servo();
+        _motor.servo.pin = pin1; // pin1 is used for servo
+        _motor.servo.angleMin = angleMin;
+        _motor.servo.angleMax = angleMax;
+        _motor.servo.currentAngle = angleMin;
+    } else {
+        _motor.coil.pin1 = pin1;
+        _motor.coil.pin2 = pin2;
+    }
+}
+
+void xDuinoRails_Turnout::begin() {
+    if (_motorType == MOTOR_SERVO) {
+        _motor.servo.servo.attach(_motor.servo.pin);
+        _motor.servo.servo.write(_motor.servo.currentAngle);
+    } else {
+        pinMode(_motor.coil.pin1, OUTPUT);
+        pinMode(_motor.coil.pin2, OUTPUT);
+        digitalWrite(_motor.coil.pin1, LOW);
+        digitalWrite(_motor.coil.pin2, LOW);
+    }
+    pinMode(_sensorPin1, INPUT_PULLUP);
+    pinMode(_sensorPin2, INPUT_PULLUP);
+}
+
+void xDuinoRails_Turnout::setPosition(int position) {
+    if (position == 1 || position == 2) {
+        _targetPosition = position;
+    }
+}
+
+void xDuinoRails_Turnout::stopMotor() {
+    if (_motorType == MOTOR_COIL) {
+        digitalWrite(_motor.coil.pin1, LOW);
+        digitalWrite(_motor.coil.pin2, LOW);
+    }
+    _state = STATE_IDLE;
+}
+
+void xDuinoRails_Turnout::update() {
+    bool sensor1_active = digitalRead(_sensorPin1) == LOW;
+    bool sensor2_active = digitalRead(_sensorPin2) == LOW;
+
+    switch (_state) {
+        case STATE_IDLE:
+            if (_targetPosition == 1 && !sensor1_active) {
+                _state = STATE_MOVING_TO_POS1;
+                _moveStartTime = millis();
+                Serial.print("Bewegung gestartet: ");
+                Serial.println(_name);
+            } else if (_targetPosition == 2 && !sensor2_active) {
+                _state = STATE_MOVING_TO_POS2;
+                _moveStartTime = millis();
+                Serial.print("Bewegung gestartet: ");
+                Serial.println(_name);
+            }
+            break;
+
+        case STATE_MOVING_TO_POS1:
+            if (sensor1_active) {
+                stopMotor();
+                Serial.print("Position 1 erreicht: ");
+                Serial.println(_name);
+            } else if (millis() - _moveStartTime > TIMEOUT_MS) {
+                stopMotor();
+                Serial.print("Timeout: ");
+                Serial.println(_name);
+            } else {
+                if (_motorType == MOTOR_SERVO) {
+                    if (millis() - _lastMoveTime > SERVO_STEP_DELAY) {
+                        if (_motor.servo.currentAngle > _motor.servo.angleMin) {
+                            _motor.servo.currentAngle--;
+                            _motor.servo.servo.write(_motor.servo.currentAngle);
+                        }
+                        _lastMoveTime = millis();
+                    }
+                } else {
+                    if (millis() - _lastMoveTime > (COIL_PULSE_ON_MS + COIL_PULSE_OFF_MS)) {
+                        digitalWrite(_motor.coil.pin1, HIGH);
+                        _lastMoveTime = millis();
+                    }
+                    if (millis() - _lastMoveTime > COIL_PULSE_ON_MS) {
+                        digitalWrite(_motor.coil.pin1, LOW);
+                    }
+                }
+            }
+            break;
+
+        case STATE_MOVING_TO_POS2:
+            if (sensor2_active) {
+                stopMotor();
+                Serial.print("Position 2 erreicht: ");
+                Serial.println(_name);
+            } else if (millis() - _moveStartTime > TIMEOUT_MS) {
+                stopMotor();
+                Serial.print("Timeout: ");
+                Serial.println(_name);
+            } else {
+                if (_motorType == MOTOR_SERVO) {
+                    if (millis() - _lastMoveTime > SERVO_STEP_DELAY) {
+                        if (_motor.servo.currentAngle < _motor.servo.angleMax) {
+                            _motor.servo.currentAngle++;
+                            _motor.servo.servo.write(_motor.servo.currentAngle);
+                        }
+                        _lastMoveTime = millis();
+                    }
+                } else {
+                    if (millis() - _lastMoveTime > (COIL_PULSE_ON_MS + COIL_PULSE_OFF_MS)) {
+                        digitalWrite(_motor.coil.pin2, HIGH);
+                        _lastMoveTime = millis();
+                    }
+                    if (millis() - _lastMoveTime > COIL_PULSE_ON_MS) {
+                        digitalWrite(_motor.coil.pin2, LOW);
+                    }
+                }
+            }
+            break;
+    }
+}
+
+// --- ThreeWayTurnout Implementation ---
+
+xDuinoRails_ThreeWayTurnout::xDuinoRails_ThreeWayTurnout(
+    int id, const char* name,
+    int coilPin1_A, int coilPin2_A, int sensorPin1_A, int sensorPin2_A,
+    int coilPin1_B, int coilPin2_B, int sensorPin1_B, int sensorPin2_B)
+    : _id(id), _name(name), _targetPosition(0)
+{
+    _turnoutA = new xDuinoRails_Turnout(id * 10 + 1, "3-Way-A", xDuinoRails_Turnout::MOTOR_COIL, coilPin1_A, coilPin2_A, sensorPin1_A, sensorPin2_A);
+    _turnoutB = new xDuinoRails_Turnout(id * 10 + 2, "3-Way-B", xDuinoRails_Turnout::MOTOR_COIL, coilPin1_B, coilPin2_B, sensorPin1_B, sensorPin2_B);
+}
+
+xDuinoRails_ThreeWayTurnout::~xDuinoRails_ThreeWayTurnout() {
+    delete _turnoutA;
+    delete _turnoutB;
+}
+
+void xDuinoRails_ThreeWayTurnout::begin() {
+    _turnoutA->begin();
+    _turnoutB->begin();
+}
+
+void xDuinoRails_ThreeWayTurnout::setPosition(int position) {
+    if (position >= 0 && position <= 2) {
+        _targetPosition = position;
+
+        // Based on the target position, command the individual turnouts.
+        // A three-way turnout is in its "straight" position when both coils are off.
+        // To go left, one coil is activated. To go right, the other is.
+        switch (_targetPosition) {
+            case 0: // Straight
+                _turnoutA->setPosition(1); // Assuming 1 is the 'off' or 'straight' state for coil A
+                _turnoutB->setPosition(1); // Assuming 1 is the 'off' or 'straight' state for coil B
+                break;
+            case 1: // Left
+                _turnoutA->setPosition(2); // Activate coil A
+                _turnoutB->setPosition(1); // Deactivate coil B
+                break;
+            case 2: // Right
+                _turnoutA->setPosition(1); // Deactivate coil A
+                _turnoutB->setPosition(2); // Activate coil B
+                break;
+        }
+    }
+}
+
+void xDuinoRails_ThreeWayTurnout::update() {
+    _turnoutA->update();
+    _turnoutB->update();
+}

--- a/lib/xDuinoRails_Turnouts/src/xDuinoRails_Turnouts.h
+++ b/lib/xDuinoRails_Turnouts/src/xDuinoRails_Turnouts.h
@@ -1,0 +1,96 @@
+#ifndef xDuinoRails_Turnouts_h
+#define xDuinoRails_Turnouts_h
+
+#include <Arduino.h>
+#include <Servo.h>
+
+class xDuinoRails_Turnout {
+public:
+    enum MotorType {
+        MOTOR_SERVO,
+        MOTOR_COIL
+    };
+
+    // Unified constructor
+    xDuinoRails_Turnout(int id, const char* name, MotorType motorType, int pin1, int pin2, int sensorPin1, int sensorPin2, int angleMin = 30, int angleMax = 150);
+
+    void begin();
+    void update();
+    void setPosition(int position); // 1 for position 1, 2 for position 2
+
+private:
+    enum State {
+        STATE_IDLE,
+        STATE_MOVING_TO_POS1,
+        STATE_MOVING_TO_POS2
+    };
+
+    void stopMotor();
+
+    // General properties
+    int _id;
+    const char* _name;
+    MotorType _motorType;
+    State _state;
+    int _targetPosition; // 0: unset, 1: pos1, 2: pos2
+
+    // Motor-specific data
+    union {
+        struct {
+            int pin;
+            int angleMin;
+            int angleMax;
+            int currentAngle;
+            Servo servo;
+        } servo;
+        struct {
+            int pin1;
+            int pin2;
+        } coil;
+    } _motor;
+
+    // Sensor pins
+    int _sensorPin1;
+    int _sensorPin2;
+
+    // Timing
+    unsigned long _moveStartTime;
+    unsigned long _lastMoveTime;
+
+    // Constants
+    static const unsigned long TIMEOUT_MS = 5000;
+    static const int SERVO_STEP_DELAY = 20;
+    static const int COIL_PULSE_ON_MS = 50;
+    static const int COIL_PULSE_OFF_MS = 150;
+};
+
+class xDuinoRails_ThreeWayTurnout {
+public:
+    xDuinoRails_ThreeWayTurnout(
+        int id,
+        const char* name,
+        // Pins for the first coil pair (e.g., for 'left' position)
+        int coilPin1_A, int coilPin2_A, int sensorPin1_A, int sensorPin2_A,
+        // Pins for the second coil pair (e.g., for 'right' position)
+        int coilPin1_B, int coilPin2_B, int sensorPin1_B, int sensorPin2_B
+    );
+
+    void begin();
+    void update();
+
+    // Positions: 0 for straight, 1 for left, 2 for right
+    void setPosition(int position);
+    ~xDuinoRails_ThreeWayTurnout();
+
+private:
+    int _id;
+    const char* _name;
+
+    // Two standard turnouts to control the two coil pairs
+    xDuinoRails_Turnout* _turnoutA;
+    xDuinoRails_Turnout* _turnoutB;
+
+    int _targetPosition; // 0: straight, 1: left, 2: right
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,214 +1,68 @@
 #include <Arduino.h>
-#include <Servo.h>
+#include <xDuinoRails_Turnouts.h>
 
-// Define motor types
-enum MotorType {
-  MOTOR_SERVO,
-  MOTOR_COIL
-};
+// Define the two-way turnout
+xDuinoRails_Turnout turnout1(
+    1,
+    "Zweiwegweiche",
+    xDuinoRails_Turnout::MOTOR_COIL,
+    D1, D2, // Coil pins
+    D3, D4  // Sensor pins
+);
 
-// Define the Turnout structure
-struct Turnout {
-  int id;
-  const char* name;
-  MotorType motorType;
-
-  union {
-    struct {
-      int pin;
-      int angleMin;
-      int angleMax;
-      int currentAngle;
-      Servo servo;
-    } servo;
-    struct {
-      int pin1;
-      int pin2;
-    } coil;
-  } motor;
-
-  int sensorPin1;
-  int sensorPin2;
-
-  enum State {
-    STATE_IDLE,
-    STATE_MOVING_TO_POS1,
-    STATE_MOVING_TO_POS2
-  } state;
-
-  int targetPosition;
-
-  unsigned long lastMoveTime;
-  unsigned long moveStartTime;
-};
-
-// --- Function Prototypes ---
-void setup();
-void loop();
-void updateTurnout(Turnout* turnout);
-void setTurnoutPosition(Turnout* turnout, int position);
-
-// --- Constants ---
-const unsigned long TIMEOUT_MS = 5000; // 5 seconds timeout for motor movement
-const int SERVO_STEP_DELAY = 20; // ms between servo steps
-const int COIL_PULSE_ON_MS = 50; // ms for coil pulse
-const int COIL_PULSE_OFF_MS = 150; // ms between coil pulses
-
-// --- Turnout Definitions ---
-const int numTurnouts = 2;
-Turnout turnouts[numTurnouts] = {
-  {
-    .id = 1,
-    .name = "Weiche 1 (Servo)",
-    .motorType = MOTOR_SERVO,
-    .motor = { .servo = { .pin = D3, .angleMin = 30, .angleMax = 150, .currentAngle = 30 } },
-    .sensorPin1 = D4,
-    .sensorPin2 = D5,
-    .state = Turnout::STATE_IDLE,
-    .targetPosition = 0
-  },
-  {
-    .id = 2,
-    .name = "Weiche 2 (Spule)",
-    .motorType = MOTOR_COIL,
-    .motor = { .coil = { .pin1 = D6, .pin2 = D7 } },
-    .sensorPin1 = D8,
-    .sensorPin2 = D9,
-    .state = Turnout::STATE_IDLE,
-    .targetPosition = 0
-  }
-};
+// Define the Märklin three-way turnout
+xDuinoRails_ThreeWayTurnout turnout2(
+    2,
+    "Dreiwegweiche",
+    D5, D6, // Coil pins A
+    D7, D8, // Sensor pins A
+    D9, D10, // Coil pins B
+    D11, D12  // Sensor pins B
+);
 
 void setup() {
-  Serial.begin(115200);
-  Serial.println("Turnout Control System Initializing");
+    Serial.begin(115200);
+    Serial.println("xDuinoRails Turnout Example: Basic-2-3");
 
-  for (int i = 0; i < numTurnouts; ++i) {
-    if (turnouts[i].motorType == MOTOR_SERVO) {
-      turnouts[i].motor.servo.servo.attach(turnouts[i].motor.servo.pin);
-      turnouts[i].motor.servo.servo.write(turnouts[i].motor.servo.currentAngle);
-    } else {
-      pinMode(turnouts[i].motor.coil.pin1, OUTPUT);
-      pinMode(turnouts[i].motor.coil.pin2, OUTPUT);
-      digitalWrite(turnouts[i].motor.coil.pin1, LOW);
-      digitalWrite(turnouts[i].motor.coil.pin2, LOW);
-    }
-    pinMode(turnouts[i].sensorPin1, INPUT_PULLUP);
-    pinMode(turnouts[i].sensorPin2, INPUT_PULLUP);
-  }
+    turnout1.begin();
+    turnout2.begin();
+
+    // Initially set the three-way turnout to straight
+    turnout2.setPosition(0);
 }
 
 void loop() {
-  for (int i = 0; i < numTurnouts; ++i) {
-    updateTurnout(&turnouts[i]);
-  }
+    // Update the state of all turnouts
+    turnout1.update();
+    turnout2.update();
 
-  static unsigned long lastToggleTime = 0;
-  static int target = 1;
-  if (millis() - lastToggleTime > 7000) {
-    Serial.print("Setting target to ");
-    Serial.println(target);
-    setTurnoutPosition(&turnouts[0], target);
-    setTurnoutPosition(&turnouts[1], target);
-    target = (target == 1) ? 2 : 1;
-    lastToggleTime = millis();
-  }
-}
+    // Example logic to cycle through turnout positions
+    static unsigned long lastToggleTime = 0;
+    static int state = 0;
+    if (millis() - lastToggleTime > 5000) { // Every 5 seconds
+        lastToggleTime = millis();
 
-void stopMotor(Turnout* turnout) {
-  if (turnout->motorType == MOTOR_COIL) {
-    digitalWrite(turnout->motor.coil.pin1, LOW);
-    digitalWrite(turnout->motor.coil.pin2, LOW);
-  }
-  // For servos, stopping is just not sending more write commands
-  turnout->state = Turnout::STATE_IDLE;
-}
-
-
-void updateTurnout(Turnout* turnout) {
-  bool sensor1_active = digitalRead(turnout->sensorPin1) == LOW;
-  bool sensor2_active = digitalRead(turnout->sensorPin2) == LOW;
-
-  // State machine logic
-  switch (turnout->state) {
-    case Turnout::STATE_IDLE:
-      if (turnout->targetPosition == 1 && !sensor1_active) {
-        turnout->state = Turnout::STATE_MOVING_TO_POS1;
-        turnout->moveStartTime = millis();
-        Serial.print("Bewegung gestartet: ");
-        Serial.println(turnout->name);
-      } else if (turnout->targetPosition == 2 && !sensor2_active) {
-        turnout->state = Turnout::STATE_MOVING_TO_POS2;
-        turnout->moveStartTime = millis();
-        Serial.print("Bewegung gestartet: ");
-        Serial.println(turnout->name);
-      }
-      break;
-
-    case Turnout::STATE_MOVING_TO_POS1:
-      if (sensor1_active) {
-        stopMotor(turnout);
-        Serial.print("Position 1 erreicht: ");
-        Serial.println(turnout->name);
-      } else if (millis() - turnout->moveStartTime > TIMEOUT_MS) {
-        stopMotor(turnout);
-        Serial.print("Timeout: ");
-        Serial.println(turnout->name);
-      } else {
-        // Continue moving
-        if (turnout->motorType == MOTOR_SERVO) {
-          if (millis() - turnout->lastMoveTime > SERVO_STEP_DELAY) {
-            if (turnout->motor.servo.currentAngle > turnout->motor.servo.angleMin) {
-              turnout->motor.servo.currentAngle--;
-              turnout->motor.servo.servo.write(turnout->motor.servo.currentAngle);
-            }
-            turnout->lastMoveTime = millis();
-          }
-        } else { // MOTOR_COIL
-          if (millis() - turnout->lastMoveTime > (COIL_PULSE_ON_MS + COIL_PULSE_OFF_MS)) {
-            digitalWrite(turnout->motor.coil.pin1, HIGH);
-            turnout->lastMoveTime = millis();
-          }
-          if (millis() - turnout->lastMoveTime > COIL_PULSE_ON_MS) {
-            digitalWrite(turnout->motor.coil.pin1, LOW);
-          }
+        switch (state) {
+            case 0:
+                Serial.println("Setting Zweiwegweiche to Position 1");
+                turnout1.setPosition(1);
+                Serial.println("Setting Dreiwegweiche to Straight (0)");
+                turnout2.setPosition(0);
+                break;
+            case 1:
+                Serial.println("Setting Zweiwegweiche to Position 2");
+                turnout1.setPosition(2);
+                break;
+            case 2:
+                 Serial.println("Setting Dreiwegweiche to Left (1)");
+                turnout2.setPosition(1);
+                break;
+            case 3:
+                Serial.println("Setting Dreiwegweiche to Right (2)");
+                turnout2.setPosition(2);
+                break;
         }
-      }
-      break;
 
-    case Turnout::STATE_MOVING_TO_POS2:
-      if (sensor2_active) {
-        stopMotor(turnout);
-        Serial.print("Position 2 erreicht: ");
-        Serial.println(turnout->name);
-      } else if (millis() - turnout->moveStartTime > TIMEOUT_MS) {
-        stopMotor(turnout);
-        Serial.print("Timeout: ");
-        Serial.println(turnout->name);
-      } else {
-        // Continue moving
-        if (turnout->motorType == MOTOR_SERVO) {
-          if (millis() - turnout->lastMoveTime > SERVO_STEP_DELAY) {
-            if (turnout->motor.servo.currentAngle < turnout->motor.servo.angleMax) {
-              turnout->motor.servo.currentAngle++;
-              turnout->motor.servo.servo.write(turnout->motor.servo.currentAngle);
-            }
-            turnout->lastMoveTime = millis();
-          }
-        } else { // MOTOR_COIL
-          if (millis() - turnout->lastMoveTime > (COIL_PULSE_ON_MS + COIL_PULSE_OFF_MS)) {
-            digitalWrite(turnout->motor.coil.pin2, HIGH);
-            turnout->lastMoveTime = millis();
-          }
-          if (millis() - turnout->lastMoveTime > COIL_PULSE_ON_MS) {
-            digitalWrite(turnout->motor.coil.pin2, LOW);
-          }
-        }
-      }
-      break;
-  }
-}
-
-void setTurnoutPosition(Turnout* turnout, int position) {
-  turnout->targetPosition = position;
+        state = (state + 1) % 4;
+    }
 }


### PR DESCRIPTION
This commit introduces a new library, xDuinoRails_Turnouts, which encapsulates the logic for controlling model railway turnouts. The library supports both servo and coil motors and includes a class for managing Märklin-style three-way turnouts.

The original `main.cpp` has been replaced with a "Basic-2-3" example that demonstrates how to use the new library to control a two-way and a three-way turnout.